### PR TITLE
Add print name for disambiguation

### DIFF
--- a/meteofrance/client.py
+++ b/meteofrance/client.py
@@ -55,6 +55,7 @@ class meteofranceClient():
                     self._city_slug = result["slug"]
                     self._rain_available = result["pluieAvalaible"]
                     self._data["name"] = result["slug"].title()
+                    self._data["printName"] = result["nomAffiche"]
                     self.postal_code = result["codePostal"]
                     self._type = result["type"]
                     if result["parent"] and result["parent"] and result["parent"]["type"] == "DEPT_FRANCE":

--- a/test.py
+++ b/test.py
@@ -8,28 +8,33 @@ class TestLocation(unittest.TestCase):
     client = meteofranceClient('oslo, norvege', True)
     data = client.get_data()
     self.assertEqual(data['name'], 'Oslo')
+    self.assertEqual(data['printName'], u'Oslo (Norvège)')
 
   def test_luxembourg(self):
     client = meteofranceClient('luxembourg', True)
     data = client.get_data()
     self.assertEqual(data['name'], 'Luxembourg')
+    self.assertEqual(data['printName'], u'Luxembourg (Luxembourg )')
 
   def test_postal_code(self):
     client = meteofranceClient('80000', True)
     data = client.get_data()
     self.assertEqual(data['name'], 'Amiens')
+    self.assertEqual(data['dept'], '80')
+    self.assertEqual(data['printName'], 'Amiens (80000)')
 
   def test_city_name(self):
     client = meteofranceClient('Brest', True)
     data = client.get_data()
     self.assertEqual(data['name'], 'Brest')
-    self.assertEqual(data['dept'], '29')
+    self.assertEqual(data['printName'], u'Brest (Biélorussie)')
 
   #postal code is not correct : should return the first result which is "Ableiges"
   def test_department(self):
     client = meteofranceClient('95', True)
     data = client.get_data()
     self.assertEqual(data['name'], 'Ableiges')
+    self.assertEqual(data['printName'], 'Ableiges (95450)')
 
   def f_test_invalid(self):
     meteofranceClient('foobar')


### PR DESCRIPTION
Tests reveal that search API now considers "Brest (Biélorussie)" instead of Brest, Brittany.
Add "printName" in data slot to help clients determine what was returned, for display in user interfaces.